### PR TITLE
LA-183, extract pertinent info from DataLake with cron-like task manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,24 @@ psql institutional_learning_data -U data_processor -f scripts/db/schema.sql
 
 ### Build
 
-`npm install`
-
-## Deployment
-
-### Install AWS CLI and EB CLI
-
 ```
 # .nvmrc file has preferred Node version
 nvm use
 npm install
-node scripts/syncToS3.js
+```
+
+## Run
+
+### Sync DataLake with contents of Canvas Data API
+
+`node scripts/syncToS3.js`
+
+### DataLake-to-database copy with cron-like task manager
+
+1. Configure the Ingest job. The `ingest.cronTime` config must have a [valid cron pattern](http://crontab.org).
+1. Start the Ingest job with:
+```
+node app
 ```
 
 ## Note

--- a/app.js
+++ b/app.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var ingestJob = require('./lib/ingest/job');
+var log = require('./lib/logger')('app');
+
+// Ingest job will keep our db synced with the DataLake.
+ingestJob.start(function() {
+  log.info("Ingest job has ended");
+});

--- a/config/default.json
+++ b/config/default.json
@@ -7,26 +7,38 @@
     },
     "s3": {
       "bucket": "xyz",
-      "region": "us-east-1",
-      "directory": "xyz/abc"
+      "directory": "xyz/abc",
+      "region": "us-east-1"
     }
   },
   "canvas": {
     "apiKey": "apiKey"
   },
+  "canvasDataApi": {
+    "host": "foo.instructure.com",
+    "https": true,
+    "key": "some key",
+    "secret": "some secret"
+  },
   "dataLake": {
     "canvasData": {
       "externalDatabase": "database",
-      "s3Location": "s3://path/to/db",
-      "iamRole": "iam role"
+      "iamRole": "iam role",
+      "s3Location": "s3://path/to/db"
     },
     "redshiftSpectrum": {
-      "user": "username",
       "database": "database",
+      "host": "redshift cluster",
       "password": "password",
       "port": 5439,
-      "host": "redshift cluster"
+      "user": "username"
     }
+  },
+  "ingest": {
+    "enabled": false,
+    "cronTime": "0 * * * *",
+    "lastExecutionDate": null,
+    "runOnInit": true
   },
   "logger": {
     "streams": [
@@ -49,12 +61,6 @@
   "platform": {
     "name": "bCourses",
     "url": "https://bcourses.berkeley.edu"
-  },
-  "canvasDataApi": {
-    "key": "some key",
-    "secret": "some secret",
-    "host": "foo.instructure.com",
-    "https": true
   },
   "statements": {
     "type": "caliper"

--- a/lib/ingest/job.js
+++ b/lib/ingest/job.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright ©2017. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var config = require('config');
+var cron = require('cron');
+var log = require('../logger')('ingestRunner');
+
+var cronTime = config.get('ingest.cronTime');
+var ingestJob = null;
+// TODO: Consider storing 'lastExecutionDate' in the db
+var lastExecutionDate = config.get('ingest.lastExecutionDate');
+
+/**
+ * Scan the DataLake and update db accordingly.
+ *
+ * @param  {Function}     [callback]            Standard callback function
+ */
+var ingestTask = function(callback) {
+  // If runOnInit=true then 'ingestJob' will be null on first iteration
+  lastExecutionDate = ingestJob ? ingestJob.lastDate() : lastExecutionDate;
+
+  log.info('Ingest task is starting...');
+
+  return callback();
+};
+
+/**
+ * This function is invoked when the ingest task is complete.
+ */
+var onComplete = function() {
+  if (ingestJob) {
+    log.info('This iteration is complete. The task will again at ' + ingestJob.nextDates(1));
+  }
+};
+
+/**
+ * Configure and start a cron-like job that will execute the Ingest task per cronTime config.
+ *
+ * @param  {Function}     [callback]            Standard callback function
+ */
+var scheduleIngest = function(callback) {
+  try {
+    var runOnInit = Boolean(config.get('ingest.runOnInit'));
+
+    ingestJob = new cron.CronJob({
+      cronTime: config.get('ingest.cronTime'),
+      onTick: ingestTask,
+      onComplete: onComplete,
+      runOnInit: runOnInit,
+      start: true,
+      timeZone: 'America/Los_Angeles'
+    });
+
+    if (!runOnInit) {
+      log.info('The first task will run at ' + ingestJob.nextDates(1));
+    }
+
+    return callback();
+
+  } catch (err) {
+    return callback(err);
+  }
+};
+
+var start = module.exports.start = function(callback) {
+  var ingestEnabled = Boolean(config.get('ingest.enabled'));
+
+  if (ingestEnabled) {
+    log.info('Ingest job is enabled; it will run according to the \'ingest.cronTime\' schedule.');
+
+    scheduleIngest(function(err) {
+      if (err) {
+        log.error({err: err}, 'We might have an invalid \'ingest.cronTime\' configuration.');
+      }
+    });
+
+  } else {
+    log.warn('Ingest is disabled. DataLake scans and db updates will not happen.');
+  }
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gulp-eslint": "4.0.0",
     "lodash": "4.17.4",
     "moment": "2.18.1",
+    "cron": "1.3.0",
     "node-redshift": "0.1.5",
     "request": "2.81.0",
     "run-sequence": "2.2.0",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-183

This PR proposes a cron-like solution for running the Ingest task: populate db (as shown in PR #6) with DataLake goodness. The next PR will begin implementation of the `ingestTask` function.