### PR TITLE
[LA-199] - Added logic to download latest request file urls corresponding to the day. 

### DIFF
--- a/lib/store/storage.js
+++ b/lib/store/storage.js
@@ -49,12 +49,14 @@ var s3 = new AWS.S3(s3Params);
  */
 var generateHash = module.exports.generateHash = function() {
   var date = moment().format('MM-DD-YYYY');
-  // Add the platform URL to the list of fields to use to generate a uuid
-  var fields = _.union([date, 'canvas_data_by_date']);
+  // Additional strings can be added to the list to create a powerful hash.
+  // Choose meaningful constant strings, as it will be required while decoding the bucket names
+  var fields = _.union([ date ]);
   // Create an MD5 hash out of the fields
   var generatedHash = crypto.createHash('md5').update(fields.join('')).digest('hex');
+  var dailyHash = generatedHash + '-' + date;
 
-  return generatedHash;
+  return dailyHash;
 };
 
 /**


### PR DESCRIPTION
Daily requests correspond to about 88 partial files. When performing a full sync to 78 tables, for requests only latest dump files that represents a days worth of activity is uploaded into S3 for starters. Fixes are also made to the daily hash generation function.