### PR TITLE
NOJIRA - node version bump in ami_config

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -13,7 +13,7 @@ packages:
 option_settings:
   # Defines node environment details for elastic beanstalk
   aws:elasticbeanstalk:container:nodejs:
-    NodeVersion: 6.11.1
+    NodeVersion: 6.11.5
     ProxyServer: apache
     NodeCommand: 'node app'
 


### PR DESCRIPTION
Bump from node version 6.11.1 to stable 6.11.5 which is supported on AWS. 