### PR TITLE
[LA-277] - List all S3 objects, compare and identify obsolete objects and run batch deletion as a part of daily data refresh

### DIFF
--- a/lib/store/storage.js
+++ b/lib/store/storage.js
@@ -28,9 +28,10 @@ var AWS = require('aws-sdk');
 var async = require('async');
 var config = require('config');
 var crypto = require('crypto');
+var fs = require('fs');
+var listAllObjects = require('s3-list-all-objects');
 var moment = require('moment');
 var request = require('request');
-var fs = require('fs');
 var util = require('util');
 
 var log = require('../core/logger')('store/storage');
@@ -206,3 +207,32 @@ var uploadFileIfNotExists = module.exports.uploadFileIfNotExists = function(file
     }
   });
 };
+
+
+/**
+ * Based on the parameters provided list all the objects within a Bucket Path
+ * This step is a pre-cursor to comparing the list of objects with latest sync files.
+ * If any of the files are out of sync after refresh they will be deleted
+ *
+ * @param  {String}           filename               Name of the file downloaded from cnavas data
+ * @param  {Function}         callback               Standard callback function
+ * @param  {Object}           callback.err           An error object, if any
+ */
+var listS3Bucket = module.exports.listS3Bucket = function(callback) {
+  // Get prefixed objects
+  var bucket = config.get('datalake.s3.bucket');
+  var path = util.format('%s/%s/',
+    config.get('datalake.canvasData.directory.currentTerm'),
+    'requests'
+    );
+
+  listAllObjects({ bucket: bucket, prefix : path}, function(err, data) {
+      console.log('Got ' + data.length + ' objects with prefix.');
+      // console.log(data);
+  });
+};
+
+
+listS3Bucket(function() {
+
+});

--- a/lib/store/storage.js
+++ b/lib/store/storage.js
@@ -136,6 +136,48 @@ var storeExtractsOnS3 = module.exports.storeExtractsOnS3 = function(file, callba
 };
 
 /**
+ * Delete objects from S3 for a given bucket and objects to be deleted as a list
+ *
+ * @param  {Object}           params                 Parameters for S3 objects to be deleted in a bucket
+ * @param  {Function}         callback               Standard callback function
+ * @param  {Object}           callback.err           An error object, if any
+ */
+var deleteObjectsFromS3 = module.exports.deleteObjectsFromS3 = function(params, callback) {
+
+  s3.deleteObjects(params, function(err, data) {
+    if (err) {
+      log.error(err, err.stack);
+      return callback(err);
+    }
+
+    log.info('Successfully deleted obsolete object');
+    log.info(data);
+    return callback();
+  });
+
+};
+
+/**
+ * Returns an array with arrays of the given size.
+ *
+ * @param sourceArray     {Array}     Array to be split in to chunks
+ * @param chunkSize      {Integer}   Size of every group
+ */
+var chunkArray = module.exports.chunkArray = function(sourceArray, chunkSize) {
+  var index = 0;
+  var arrayLength = sourceArray.length;
+  var tempArray = [];
+
+  for (index = 0; index < arrayLength; index += chunkSize) {
+    chunk = sourceArray.slice(index, index + chunkSize);
+    // Do something if you want with the group
+    tempArray.push(myChunk);
+  }
+
+  return tempArray;
+};
+
+/**
  * Download the complete snapshot of Canvas Redshift data files. This api call
  * retrieves full and partial file dumps to perform a canavs data refresh on the data loch. Requests related to
  * only current term are uploaded to S3. The rest are organized on a daily basis.
@@ -195,10 +237,10 @@ var uploadFileIfNotExists = module.exports.uploadFileIfNotExists = function(file
         log.info('Possible bad request or S3 params failure. Check if S3 multi part uploads or transfer acceleration is enabled');
         return callback(err);
 
-      } else {
-        // TODO: Error handling will be further improved once metadata collection process is added.
-        return callback(err);
       }
+
+      // TODO: Error handling will be further improved once metadata collection process is added.
+      return callback(err);
 
     } else if (data) {
       log.info('File already exists. Skipping');
@@ -208,86 +250,86 @@ var uploadFileIfNotExists = module.exports.uploadFileIfNotExists = function(file
   });
 };
 
-
 /**
- * Based on the parameters provided list all the objects within a Bucket Path
- * This step is a pre-cursor to comparing the list of objects with latest sync files.
- * If any of the files are out of sync after refresh they will be deleted
+ * We compare the list of objects in S3 bucket with the list of filenames obtained /sync API.
+ * Mark files as obselete and create a finalized list. Create batches and trigger S3 batch
+ * deletion delete method to perform the clean up.
  *
- * @param  {String}           filename               Name of the file downloaded from cnavas data
+ * @param  {String}           latestSyncFileNames    Name of the file downloaded from cnavas data
  * @param  {Function}         callback               Standard callback function
  * @param  {Object}           callback.err           An error object, if any
  */
- var cleanUpObseleteFiles = module.exports.cleanUpObseleteFiles = function(latestSyncFileNames, callback) {
-   // Get prefixed objects
-   var bucket = config.get('datalake.s3.bucket');
-   var path = util.format('%s/%s/',
-   config.get('datalake.canvasData.directory.currentTerm'),
-   'requests'
- );
- var obseleteFiles = [];
+var cleanUpObsoleteFiles = module.exports.cleanUpObsoleteFiles = function(latestSyncFileNames, callback) {
+  // Get prefixed objects
+  var bucket = config.get('datalake.s3.bucket');
+  var path = util.format('%s/%s/',
+    config.get('datalake.canvasData.directory.currentTerm'),
+    'requests'
+  );
+  var obsoleteFiles = [];
 
- listAllObjects({ bucket: bucket, prefix : path}, function(err, data) {
-   console.log('Got ' + data.length + ' objects with prefix.');
-   // console.log(data);
-
-   async.eachSeries(data, function(s3File, done) {
-     var s3FileName = s3File.Key.split(path)[1];
-     // console.log(s3FileName);
-
-     var s3FileFound = latestSyncFileNames.find(function(filename) {
-       return filename === s3FileName;
-     });
-
-     if (!s3FileFound) {
-       log.info('File is obselete: ' + s3FileName);
-       obseleteFiles.push({ Key: path + s3FileName });
-     }
-
-     return done();
-
-   }, function() {
-
-     if (obseleteFiles.length) {
-       log.info('ObseleteFiles List \n');
-       log.info(obseleteFiles);
-
-
-       var deleteParams = {
-         Bucket: bucket,
-         Delete: { // required
-           Objects: obseleteFiles
-         },
-       };
-
-       deleteObjectsFromS3(deleteParams, function(err) {
-         if(err) {
-           return callback(err);
-         }
-
-         return callback();
-       });
-
-     } else {
-       log.info('No obselete files found. Refresh successful.');
-       return callback();
-     }
-   });
- });
-};
-
-
-var deleteObjectsFromS3 = module.exports.deleteObjectsFromS3 = function(params, callback) {
-
-  s3.deleteObjects(params, function(err, data) {
+  listAllObjects({bucket: bucket, prefix: path}, function(err, data) {
     if (err) {
-      log.error(err, err.stack); // an error occurred
+      log.error('Could not list all the objects in the bucket.');
       return callback(err);
+
     }
 
-    log.info('Successfully deleted obselete object');
-    log.info(data);
-    return callback();           // successful response
-  });
+    log.info('Got ' + data.length + ' objects with prefix.');
+    async.eachSeries(data, function(s3File, done) {
+      var s3FileName = s3File.Key.split(path)[1];
+      var s3Key = s3File.Key;
+      var s3FileFound = latestSyncFileNames.find(function(filename) {
+        return filename === s3FileName;
+      });
 
+      if (!s3FileFound) {
+        deleteFile = {Key: s3Key};
+        obsoleteFiles.push(deleteFile);
+      }
+
+      setImmediate(done);
+
+    }, function() {
+
+      if (obsoleteFiles.length) {
+        // S3 batch delete API accepts 1000 objects as an XML input.
+        // We create mutiple chunks of size 1000 and perform batch deletions.
+        var obsoleteFilesArrayChunks = chunkArray(obsoleteFiles, 999);
+        log.info('No. of obsolete files marked for S3 batch object deletion: ' + obsoleteFiles.length);
+
+        async.eachSeries(obsoleteFilesArrayChunks, function(obsoleteFileChunk, next) {
+          var deleteParams = {
+            Bucket: bucket,
+            Delete: {
+              // Required paramter: objects to deleted. Max permitted list size for batch deletion is 1000 objects.
+              Objects: obsoleteFileChunk
+            }
+          };
+
+          deleteObjectsFromS3(deleteParams, function(err) {
+            if (err) {
+              return next(err);
+            }
+
+            return next();
+          });
+
+        }, function(err) {
+          if (err) {
+            log.error(err, err.stack);
+            return callback(err);
+          }
+
+          log.info('Completed clean up of obsolete Files. All Done.');
+          return callback();
+        });
+
+      } else {
+        log.info('No obsolete files found. Refresh successful.');
+        return callback();
+
+      }
+    });
+  });
 };

--- a/lib/store/storage.js
+++ b/lib/store/storage.js
@@ -218,21 +218,76 @@ var uploadFileIfNotExists = module.exports.uploadFileIfNotExists = function(file
  * @param  {Function}         callback               Standard callback function
  * @param  {Object}           callback.err           An error object, if any
  */
-var listS3Bucket = module.exports.listS3Bucket = function(callback) {
-  // Get prefixed objects
-  var bucket = config.get('datalake.s3.bucket');
-  var path = util.format('%s/%s/',
-    config.get('datalake.canvasData.directory.currentTerm'),
-    'requests'
-    );
+ var cleanUpObseleteFiles = module.exports.cleanUpObseleteFiles = function(latestSyncFileNames, callback) {
+   // Get prefixed objects
+   var bucket = config.get('datalake.s3.bucket');
+   var path = util.format('%s/%s/',
+   config.get('datalake.canvasData.directory.currentTerm'),
+   'requests'
+ );
+ var obseleteFiles = [];
 
-  listAllObjects({ bucket: bucket, prefix : path}, function(err, data) {
-      console.log('Got ' + data.length + ' objects with prefix.');
-      // console.log(data);
-  });
+ listAllObjects({ bucket: bucket, prefix : path}, function(err, data) {
+   console.log('Got ' + data.length + ' objects with prefix.');
+   // console.log(data);
+
+   async.eachSeries(data, function(s3File, done) {
+     var s3FileName = s3File.Key.split(path)[1];
+     // console.log(s3FileName);
+
+     var s3FileFound = latestSyncFileNames.find(function(filename) {
+       return filename === s3FileName;
+     });
+
+     if (!s3FileFound) {
+       log.info('File is obselete: ' + s3FileName);
+       obseleteFiles.push({ Key: path + s3FileName });
+     }
+
+     return done();
+
+   }, function() {
+
+     if (obseleteFiles.length) {
+       log.info('ObseleteFiles List \n');
+       log.info(obseleteFiles);
+
+
+       var deleteParams = {
+         Bucket: bucket,
+         Delete: { // required
+           Objects: obseleteFiles
+         },
+       };
+
+       deleteObjectsFromS3(deleteParams, function(err) {
+         if(err) {
+           return callback(err);
+         }
+
+         return callback();
+       });
+
+     } else {
+       log.info('No obselete files found. Refresh successful.');
+       return callback();
+     }
+   });
+ });
 };
 
 
-listS3Bucket(function() {
+var deleteObjectsFromS3 = module.exports.deleteObjectsFromS3 = function(params, callback) {
 
-});
+  s3.deleteObjects(params, function(err, data) {
+    if (err) {
+      log.error(err, err.stack); // an error occurred
+      return callback(err);
+    }
+
+    log.info('Successfully deleted obselete object');
+    log.info(data);
+    return callback();           // successful response
+  });
+
+};

--- a/lib/store/syncDumps.js
+++ b/lib/store/syncDumps.js
@@ -169,7 +169,7 @@ var migrateDataToS3 = function(callback) {
     // For fall2017 the Reg Exp is as follows: Add it in the config file to reflect date ranges
     // '(.requests\/201708.)|(.requests\/201709.)|(.requests\/201710.)|(.requests\/201711.)|(.requests\/201712.)'
     var requestsTermRegExp = new RegExp(config.get('datalake.canvasData.requestsTermRegExp'));
-    async.eachSeries(fileDump.files, function(file, done) {
+    _.each(fileDump.files, function(file) {
       if (file.table !== 'requests') {
         files.push(file);
         filenames.push(file.filename);
@@ -178,35 +178,38 @@ var migrateDataToS3 = function(callback) {
         filenames.push(file.filename);
       }
 
-      return done();
+    });
 
-    }, function() {
-      log.info('Number of files found: ' + files.length);
-      var path = '/uploadFileToS3';
+    log.info('Number of files found: ' + files.length);
+    var path = '/uploadFileToS3';
 
-      async.eachSeries(files, function(file, done) {
-        // Send a request to elastic beanstalk instance
-        cdpApiRequest(file, path, function(err) {
-          if (err) {
-            log.error({file: file.filename}, 'Failed to get file from Canvas Data');
-            return done();
-          }
-
-          log.info({file: file.filename}, 'Processing File upoad to S3');
+    async.eachSeries(files, function(file, done) {
+      // Send a request to elastic beanstalk instance
+      cdpApiRequest(file, path, function(err) {
+        if (err) {
+          log.error({file: file.filename}, 'Failed to get file from Canvas Data');
           return done();
-        });
+        }
 
-      }, function() {
-        log.info('Added all request files !');
-        storage.cleanUpObseleteFiles(filenames, function(err) {
-          if (err) {
-            return callback(err);
-          }
+        log.info({file: file.filename}, 'Processing File upoad to S3');
+        return done();
 
-          log.info('Found clean up list');
-          return callback();
+      });
+    }, function() {
+      log.info('Synced latest data dump files to S3 storage.');
 
-        });
+      // Once the daily sync process to upload files to S3 is complete, we look for any
+      // outdated files that needs to cleaned up from the S3 buckets.
+      // A quick comparison between the sync files vs s3 Bucket files help us identify if
+      // there are any obsoleteFiles that needs to be removed.
+      storage.cleanUpObsoleteFiles(filenames, function(err) {
+        if (err) {
+          return callback(err);
+        }
+
+        log.info('Clean up of obsolete files complete.');
+        return callback();
+
       });
     });
   });

--- a/lib/store/syncDumps.js
+++ b/lib/store/syncDumps.js
@@ -160,6 +160,7 @@ var migrateDataToS3 = function(callback) {
   // Get the list of files, tables and signed URLs that contain complete Canvas data snapshots
   canvas.dataApiRequest('/file/sync', function(fileDump) {
     var files = [];
+    var filenames = [];
 
     // The requests complete dump file urls can be parsed to identify the files corresponding to a specific data range.
     // These fies are often large and take a time to sync and upload. Use a RegExp as shown below in the
@@ -168,32 +169,45 @@ var migrateDataToS3 = function(callback) {
     // For fall2017 the Reg Exp is as follows: Add it in the config file to reflect date ranges
     // '(.requests\/201708.)|(.requests\/201709.)|(.requests\/201710.)|(.requests\/201711.)|(.requests\/201712.)'
     var requestsTermRegExp = new RegExp(config.get('datalake.canvasData.requestsTermRegExp'));
-    _.each(fileDump.files, function(file) {
+    async.eachSeries(fileDump.files, function(file, done) {
       if (file.table !== 'requests') {
         files.push(file);
+        filenames.push(file.filename);
       } else if (((file.table === 'requests') && file.partial === true) || (requestsTermRegExp.test(file.url) && file.partial === false)) {
         files.push(file);
+        filenames.push(file.filename);
       }
-    });
 
-    log.info('Number of files found: ' + files.length);
-    var path = '/uploadFileToS3';
-
-    async.eachSeries(files, function(file, done) {
-      // Send a request to elastic beanstalk instance
-      cdpApiRequest(file, path, function(err) {
-        if (err) {
-          log.error({file: file.filename}, 'Failed to get file from Canvas Data');
-          return done();
-        }
-
-        log.info({file: file.filename}, 'Processing File upoad to S3');
-        return done();
-      });
+      return done();
 
     }, function() {
-      log.info('Added all request files !');
-      return callback();
+      log.info('Number of files found: ' + files.length);
+      var path = '/uploadFileToS3';
+
+      async.eachSeries(files, function(file, done) {
+        // Send a request to elastic beanstalk instance
+        cdpApiRequest(file, path, function(err) {
+          if (err) {
+            log.error({file: file.filename}, 'Failed to get file from Canvas Data');
+            return done();
+          }
+
+          log.info({file: file.filename}, 'Processing File upoad to S3');
+          return done();
+        });
+
+      }, function() {
+        log.info('Added all request files !');
+        storage.cleanUpObseleteFiles(filenames, function(err) {
+          if (err) {
+            return callback(err);
+          }
+
+          log.info('Found clean up list');
+          return callback();
+
+        });
+      });
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "node-redshift": "0.1.5",
     "request": "2.81.0",
     "run-sequence": "2.2.0",
+    "s3-list-all-objects": "0.1.0",
     "s3-upload-stream": "1.0.7",
     "yargs": "8.0.2"
   },
   "engines": {
-    "node": "6.10"
+    "node": "6.11.5"
   },
   "scripts": {
     "pretest": "echo 'Clean up old artifacts before running tests'; rm -f logs/test.log",


### PR DESCRIPTION
The requests data dumps from Canvas are organized by active term and historical data. After the daily download of files has been run, added a routine to identify and clean up any obsolete files to keep the data inline with the list provided by /sync API.

Added: s3 utils like
1) listing the objects in a bucket and a specified path.
2) S3 batch deletion options of obsolete objects
3) Refresh the fall-2017/spring-2018 buckets by running the clean up routine.