### PR TITLE
[LA-279] Fixed memory leak warnings and cron REST api calls

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,10 +35,13 @@ DataLoch.init(function(err) {
 
   log.info('Data Loch Server has started. Brace yourself for awesomeness');
 
-  cron.start(function(callback) {
+  cron.start(function(err) {
+    if (err) {
+      log.error({err: err}, 'We might have an invalid cron configuration.');
+    }
+
     log.info('Cron started.');
-
     return;
-  });
 
+  });
 });

--- a/lib/core/server.js
+++ b/lib/core/server.js
@@ -27,8 +27,11 @@ var _ = require('lodash');
 var bodyParser = require('body-parser');
 var config = require('config');
 var express = require('express');
+var events = require('events')
 var http = require('http');
 var util = require('util');
+
+
 
 var log = require('./logger')('core/server');
 
@@ -48,6 +51,9 @@ var setUpServer = module.exports.setUpServer = function() {
   var port = config.get('app.port');
 
   app.httpServer.listen(port, 'localhost');
+
+  // Increase default max event listeners
+  events.EventEmitter.defaultMaxListeners = Infinity;
 
   // Don't output pretty JSON
   app.set('json spaces', 0);

--- a/lib/cron/rest.js
+++ b/lib/cron/rest.js
@@ -47,14 +47,13 @@ DataLoch.apiRouter.post('/syncCanvasDumps', function(req, res) {
     syncDumps.run(function(err) {
       if (err) {
         log.error(err);
-        return res.status(err.code).send(err.msg);
       }
 
       log.info('Canvas Dumps successfully refreshed on S3.');
-      return res.sendStatus(200);
-
     });
   }
+
+  return res.status(200).send('Triggered cron script successfully');
 });
 
 /* !
@@ -74,12 +73,11 @@ DataLoch.apiRouter.post('/createCanvasSchema', function(req, res) {
     syncDb.run(function(err) {
       if (err) {
         log.error(err);
-        return res.status(err.code).send(err.msg);
       }
 
       log.info('Canvas Databases successfully refreshed on Redshift.');
-      return res.sendStatus(200);
-
     });
   }
+
+  return res.status(200).send('Triggered cron script successfully');
 });


### PR DESCRIPTION
After intense debugging using memwatch, node-inspector and analyzing heap dump snapshots, the results did not yield any possible leaks. I found that to node by default sets number of active listeners to 10 and throws a warning there after. The solution turned out to be much simpler. Set the default max listeners to infinity or 0 depending on the node version you are using.

Refer
https://github.com/nodejs/node-v0.x-archive/issues/22987

For latest version NodeJS we need to add below line at very starting of your server file: 
    require('events').EventEmitter.defaultMaxListeners = Infinity;

For Older version 0.10A:
    require('events').EventEmitter.defaultMaxListeners = 0;

Also, fixed the response to the REST APIs for triggering cron jobs. Now the response won't wait for job execution to complete. It just gives a status if cron has been successfully triggered.