### PR TITLE
[LA-293, LA-283] - Stream error handling and canvas schema template fixes.

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -19,14 +19,20 @@ option_settings:
 
   # Defines launch configurations for the environment and auto scaling group
   aws:autoscaling:launchconfiguration:
-    InstanceType: t2.micro
+    InstanceType: t2.medium
     EC2KeyName: cloudlrs-aws-eb
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
+    SSHSourceRestriction: tcp, 22, 22, sg-8ece7af1
 
   # Load Balancer configurations
   aws:elasticbeanstalk:environment:
     LoadBalancerType: application
     ServiceRole: aws-elasticbeanstalk-service-role
+
+  # Load Balancer security group
+  aws:elbv2:loadbalancer:
+    SecurityGroups: [sg-40c5713f]
+    ManagedSecurityGroup: sg-40c5713f
 
   # Disable the load balancer's default listener on port 80.
   aws:elbv2:listener:default:

--- a/lib/store/storage.js
+++ b/lib/store/storage.js
@@ -108,6 +108,17 @@ var storeExtractsOnS3 = module.exports.storeExtractsOnS3 = function(file, callba
   var s3upload = s3Stream.upload(putParams);
   var start = Date.now();
 
+  // TODO: Add metadata table updates once s3 uploads are complete or when errors occur.
+  // error handling for s3 upload streams.
+  s3upload.on('error', function(err) {
+    log.error({err: err, file: file.filename}, 'Error streaming file part to S3 bucket.');
+  });
+
+  s3upload.on('uploaded', function() {
+    var end = Date.now();
+    log.info({file: file.filename, duration: end - start}, 'Finished multi part upload of the Canvas data file to S3');
+  });
+
   // Get the data dump file from Canvas Data API and return a callback if the dump is available.
   // The data dump will be uploaded asynchronouly after sending the acknowledgement.
   // TODO: Write the processing result to the metadata table once the file is processed. The table can
@@ -119,11 +130,8 @@ var storeExtractsOnS3 = module.exports.storeExtractsOnS3 = function(file, callba
           .on('error', function(err) {
             log.error(err);
             log.error({err: err, file: file.filename}, 'Unable to gunzip Canvas data file stream');
-          })
-          .on('finish', function() {
-            var end = Date.now();
-            log.info({file: file.filename, duration: end - start}, 'Finished Canvas data file upload');
           });
+
       } else if (res.statusCode === 400) {
         log.error({code: res.statusCode, msg: 'Bad request. Check if file urls are correct'});
       } else if (res.statusCode === 404) {

--- a/lib/sync/db-templates/dbCreation.template.sql
+++ b/lib/sync/db-templates/dbCreation.template.sql
@@ -635,7 +635,5 @@ CREATE EXTERNAL TABLE <%= externalSchema %>.historical_requests_parquet(
     http_status VARCHAR,
     http_version VARCHAR
 )
-ROW FORMAT DELIMITED
-FIELDS TERMINATED BY '\t'
-STORED AS TEXTFILE
+STORED AS PARQUET
 LOCATION '<%= s3RequestsHistoricalLocation %>/requests-parquet-snappy';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "data-loch",
   "description": "Instructure Canvas Redshift Processor",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/data-loch.git"
@@ -33,7 +33,7 @@
     "mixpanel-data-export": "latest",
     "mixpanel-data-export-node": "latest",
     "mocha": "^4.0.1",
-    "moment": "2.18.1",
+    "moment": "2.19.3",
     "moment-timezone": "0.5.13",
     "node-redshift": "0.1.5",
     "request": "2.81.0",


### PR DESCRIPTION
The PR contains the following
- S3 upload streams error handling. 
- Updates to package.json. 
- Fixes to canvas schema templates.

The s3-upload-stream used 'uploaded' event instead of 'finish' event listener. Suitable error handlers and log messages were added to upload or exit gracefully.